### PR TITLE
fix: Revert "fix(deps): Update dependency cloudquery/helm-charts to v1"

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,7 @@ variable "install_helm_chart" {
 variable "chart_version" {
   description = "The version of CloudQuery helm chart"
   type        = string
-  default     = "1.0.0" # Do not change CloudQuery helm chart version as it is automatically updated by Workflow
+  default     = "0.3.3" # Do not change CloudQuery helm chart version as it is automatically updated by Workflow
 }
 
 variable "config_file" {


### PR DESCRIPTION
This reverts commit ae3d3807257ed4a345685cc787313e2088b06409.

Since https://github.com/cloudquery/terraform-aws-cloudquery/pull/71 is a major version bump we need to do the update manually.

For example, https://github.com/cloudquery/terraform-aws-cloudquery/blob/0206a06c12e98d3235bdbfd1f92550f279c9e6cc/charts.tf#L10 should be `CQ_DSN`

https://github.com/cloudquery/.github/pull/357 should prevent this from happening in the future