### PR TITLE
chore(ci): Use cq-bot token to commit changes

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -41,7 +41,7 @@ jobs:
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.6.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
-          args: 'terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*'
+          args: "terraform_validate --color=always --show-diff-on-failure --files ${{ matrix.directory }}/*"
 
       - name: Pre-commit Terraform ${{ steps.minMax.outputs.minVersion }}
         # Run only validate pre-commit check on min version supported
@@ -49,7 +49,7 @@ jobs:
         uses: clowdhaus/terraform-composite-actions/pre-commit@v1.6.0
         with:
           terraform-version: ${{ steps.minMax.outputs.minVersion }}
-          args: 'terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)'
+          args: "terraform_validate --color=always --show-diff-on-failure --files $(ls *.tf)"
 
   preCommitMaxVersion:
     name: Max TF pre-commit
@@ -58,9 +58,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        if: github.actor != 'cq-bot'
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{github.event.pull_request.head.repo.full_name}}
+      - name: Checkout
+        uses: actions/checkout@v3
+        if: github.actor == 'cq-bot'
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
+          token: ${{ secrets.GH_CQ_BOT }}
 
       - name: Terraform min/max versions
         id: minMax


### PR DESCRIPTION
This is required so when we commit the version bump and docs changes we trigger the test workflows again